### PR TITLE
feat: add hooks in generate mode before and after file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Hooks are listeners to Nuxt events. [Learn more](https://nuxtjs.org/docs/configu
 | Hook                   | Arguments             | When                               |
 | ---------------------- | --------------------- | ---------------------------------- |
 | robots:generate:before | (nuxt, robotsOptions) | Hook on before site generation     |
-| robots:generate:done   | (nuxt)                | Hook on robots generation finished |
+| robots:generate:done   | (nuxt, robotsContent) | Hook on robots generation finished |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Disallow: /admin
 
 **Note:** Don't worry keys are parsed with case insensitive and special characters.
 
+## Hooks
+
+Hooks are listeners to Nuxt events. [Learn more](https://nuxtjs.org/docs/configuration-glossary/configuration-hooks/)
+
+| Hook                   | Arguments             | When                               |
+| ---------------------- | --------------------- | ---------------------------------- |
+| robots:generate:before | (nuxt, robotsOptions) | Hook on before site generation     |
+| robots:generate:done   | (nuxt)                | Hook on robots generation finished |
+
 ## License
 
 [MIT License](./LICENSE)

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -7,11 +7,14 @@ import { FILE_NAME, getRules, render } from './utils'
 export function generate (options: Rule[]) {
   this.nuxt.hook('generate:done', async () => {
     await this.nuxt.callHook('robots:generate:before', this, options)
+
     const { rootDir, generate: { dir: generateDir } } = this.options
     const generateFilePath = resolve(rootDir, generateDir, FILE_NAME)
     const rules: RuleInterface[] = await getRules.call(this, options)
+    const content = render([...getStaticRules(), ...rules])
 
-    writeFileSync(generateFilePath, render([...getStaticRules(), ...rules]))
-    await this.nuxt.callHook('robots:generate:done', this)
+    writeFileSync(generateFilePath, content)
+
+    await this.nuxt.callHook('robots:generate:done', this, content)
   })
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -6,10 +6,12 @@ import { FILE_NAME, getRules, render } from './utils'
 
 export function generate (options: Rule[]) {
   this.nuxt.hook('generate:done', async () => {
+    await this.nuxt.callHook('robots:generate:before', this, options)
     const { rootDir, generate: { dir: generateDir } } = this.options
     const generateFilePath = resolve(rootDir, generateDir, FILE_NAME)
     const rules: RuleInterface[] = await getRules.call(this, options)
 
     writeFileSync(generateFilePath, render([...getStaticRules(), ...rules]))
+    await this.nuxt.callHook('robots:generate:done', this)
   })
 }


### PR DESCRIPTION
**Why** is the change needed?

The current implementation only resolves the options used
to generate the robots.txt statically from nuxt.config.js.
This limits the module's use cases as it is not possible to extend
the config from another nuxt module during static site generation.

**How** is the need addressed?

By using the same pattern as [@nuxtjs/sitemap](https://sitemap.nuxtjs.org/usage/hooks) do for [this feature](https://github.com/nuxt-community/sitemap-module/blob/dev/lib/module.js)

- Calling robots:generate:before hook passing options before file generation
- Calling robots:generate:done hook after file generation

What **side-effects** could the change have?

- The options can be modified by other nuxt modules during generation