### PR TITLE
feat: introduce options to inject headers and footers as a comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublishOnly": "yarn build",
     "dev": "nuxt dev test/fixture/basic",
     "lint": "eslint --ext .js,.ts,.vue .",
+    "format": "eslint --ext .js,.ts,.vue . --fix",
     "release": "yarn test && yarn build && standard-version && git push --follow-tags && npm publish",
     "test": "yarn lint && yarn jest"
   },

--- a/src/build.ts
+++ b/src/build.ts
@@ -4,6 +4,24 @@ import { FILE_NAME, getRules, parseFile } from './utils'
 import { RuleInterface } from './types'
 
 let staticRules: RuleInterface[] = []
+let staticHeader: string = ''
+let staticFooter: string = ''
+
+function setStaticHeader (newStaticHeader: string) {
+  staticHeader = newStaticHeader
+}
+
+export function getStaticHeader () {
+  return staticHeader
+}
+
+function setStaticFooter (newStaticFooter: string) {
+  staticFooter = newStaticFooter
+}
+
+export function getStaticFooter () {
+  return staticFooter
+}
 
 function setStaticRules (newStaticRules: RuleInterface[]) {
   staticRules = newStaticRules
@@ -13,6 +31,10 @@ export function getStaticRules () {
   return staticRules
 }
 
+function parseFileComments (content: string) {
+  return content.split('\n').filter(str => str.indexOf('#') === 0).join('\n')
+}
+
 export function build () {
   this.nuxt.hook('build:before', async () => {
     const { srcDir, dir: { static: staticDir } } = this.options
@@ -20,6 +42,9 @@ export function build () {
 
     if (existsSync(staticFilePath)) {
       const content = readFileSync(staticFilePath).toString()
+
+      setStaticHeader(parseFileComments(content))
+      setStaticFooter('')
 
       setStaticRules(await getRules.call(this, parseFile(content)))
     }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -11,7 +11,7 @@ export function generate (options: Rule[]) {
     const { rootDir, generate: { dir: generateDir } } = this.options
     const generateFilePath = resolve(rootDir, generateDir, FILE_NAME)
     const rules: RuleInterface[] = await getRules.call(this, options)
-    const content = render([...getStaticRules(), ...rules])
+    const content = render('', [...getStaticRules(), ...rules])
 
     writeFileSync(generateFilePath, content)
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { writeFileSync } from 'fs'
-import { getStaticRules } from './build'
+import { getStaticFooter, getStaticHeader, getStaticRules } from './build'
 import { RuleInterface, Rule } from './types'
 import { FILE_NAME, getRules, render } from './utils'
 
@@ -11,7 +11,7 @@ export function generate (options: Rule[]) {
     const { rootDir, generate: { dir: generateDir } } = this.options
     const generateFilePath = resolve(rootDir, generateDir, FILE_NAME)
     const rules: RuleInterface[] = await getRules.call(this, options)
-    const content = render('', [...getStaticRules(), ...rules])
+    const content = render(getStaticHeader(), [...getStaticRules(), ...rules], getStaticFooter())
 
     writeFileSync(generateFilePath, content)
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,22 @@
-import { getStaticRules } from './build'
+import { getStaticFooter, getStaticHeader, getStaticRules } from './build'
 import { RuleInterface, Rule } from './types'
 import { FILE_NAME, getRules, render } from './utils'
+
+function resolveHeader (header, staticHeader) {
+  if (header) { return header }
+
+  if (staticHeader) { return staticHeader }
+
+  return ''
+}
+
+function resolveFooter (footer, staticHeader) {
+  if (footer) { return footer }
+
+  if (staticHeader) { return staticHeader }
+
+  return ''
+}
 
 export function middleware (options: Rule[]) {
   this.nuxt.hook('render:setupMiddleware', () => {
@@ -10,10 +26,11 @@ export function middleware (options: Rule[]) {
       path: FILE_NAME,
       async handler (req, res) {
         const rules: RuleInterface[] = await getRules.call(moduleContainer, options, req)
-        const header = ((options[0]?.Header || '') as string).split('\n').filter(Boolean).map(str => `# ${str}`).join()
+        const header = resolveHeader(((options[0]?.Header || '') as string).split('\n').filter(Boolean).map(str => `# ${str}`).join(), getStaticHeader())
+        const footer = resolveFooter(((options[0]?.Footer || '') as string).split('\n').filter(Boolean).map(str => `# ${str}`).join(), getStaticFooter())
 
         res.setHeader('Content-Type', 'text/plain')
-        res.end(render(header, [...getStaticRules(), ...rules]))
+        res.end(render(header, [...getStaticRules(), ...rules], footer))
       }
     })
   })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,9 +10,10 @@ export function middleware (options: Rule[]) {
       path: FILE_NAME,
       async handler (req, res) {
         const rules: RuleInterface[] = await getRules.call(moduleContainer, options, req)
+        const header = ((options[0]?.Header || '') as string).split('\n').filter(Boolean).map(str => `# ${str}`).join()
 
         res.setHeader('Content-Type', 'text/plain')
-        res.end(render([...getStaticRules(), ...rules]))
+        res.end(render(header, [...getStaticRules(), ...rules]))
       }
     })
   })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,8 +48,8 @@ function parseRule (item: Rule) {
   return parsed
 }
 
-export function render (rules: RuleInterface[]) {
-  return rules.map(rule => `${rule.key}: ${String(rule.value).trim()}`).join('\n')
+export function render (prefix: string = null, rules: RuleInterface[]) {
+  return [prefix, ...rules.map(rule => `${rule.key}: ${String(rule.value).trim()}`)].filter(Boolean).join('\n')
 }
 
 export function parseFile (content: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,8 +48,8 @@ function parseRule (item: Rule) {
   return parsed
 }
 
-export function render (prefix: string = null, rules: RuleInterface[]) {
-  return [prefix, ...rules.map(rule => `${rule.key}: ${String(rule.value).trim()}`)].filter(Boolean).join('\n')
+export function render (header: string = '', rules: RuleInterface[], footer: string = '') {
+  return [header, ...rules.map(rule => `${rule.key}: ${String(rule.value).trim()}`), footer].filter(Boolean).join('\n')
 }
 
 export function parseFile (content: string) {

--- a/test/fixture/static-with-header/nuxt.config.js
+++ b/test/fixture/static-with-header/nuxt.config.js
@@ -1,0 +1,7 @@
+export default {
+  target: 'static',
+  rootDir: __dirname,
+  modules: [
+    '../../../src/module.ts'
+  ]
+}

--- a/test/fixture/static-with-header/static/robots.txt
+++ b/test/fixture/static-with-header/static/robots.txt
@@ -1,3 +1,4 @@
 # Comment
+#comment with space
 foo: bar // unrecognized
 Disallow: /foo

--- a/test/fixture/static-with-header/static/robots.txt
+++ b/test/fixture/static-with-header/static/robots.txt
@@ -1,0 +1,3 @@
+# Comment
+foo: bar // unrecognized
+Disallow: /foo

--- a/test/fixture/with-object-and-footer/nuxt.config.js
+++ b/test/fixture/with-object-and-footer/nuxt.config.js
@@ -1,0 +1,11 @@
+export default {
+  rootDir: __dirname,
+  modules: [
+    '../../../src/module.ts'
+  ],
+  robots: {
+    UserAgent: 'Googlebot',
+    Disallow: () => '/',
+    Footer: 'Comment'
+  }
+}

--- a/test/fixture/with-object-and-header/nuxt.config.js
+++ b/test/fixture/with-object-and-header/nuxt.config.js
@@ -1,0 +1,11 @@
+export default {
+  rootDir: __dirname,
+  modules: [
+    '../../../src/module.ts'
+  ],
+  robots: {
+    Header: 'Comment',
+    UserAgent: 'Googlebot',
+    Disallow: () => '/'
+  }
+}

--- a/test/static-with-header.test.ts
+++ b/test/static-with-header.test.ts
@@ -1,0 +1,13 @@
+import { setupTest, get } from '@nuxt/test-utils'
+
+describe('static', () => {
+  setupTest({
+    server: true,
+    fixture: 'fixture/static-with-header'
+  })
+
+  test('render', async () => {
+    const { body } = await get('/robots.txt')
+    expect(body).toBe('Disallow: /foo\nUser-agent: *\nDisallow: ')
+  })
+})

--- a/test/with-object-and-footer.test.ts
+++ b/test/with-object-and-footer.test.ts
@@ -1,13 +1,13 @@
 import { setupTest, get } from '@nuxt/test-utils'
 
-describe('static', () => {
+describe('with function', () => {
   setupTest({
     server: true,
-    fixture: 'fixture/static-with-header'
+    fixture: 'fixture/with-object-and-footer'
   })
 
   test('render', async () => {
     const { body } = await get('/robots.txt')
-    expect(body).toBe('# Comment\n#comment with space\nDisallow: /foo\nUser-agent: *\nDisallow: ')
+    expect(body).toBe('User-agent: Googlebot\nDisallow: /\n# Comment')
   })
 })

--- a/test/with-object-and-header.test.ts
+++ b/test/with-object-and-header.test.ts
@@ -1,0 +1,13 @@
+import { setupTest, get } from '@nuxt/test-utils'
+
+describe('with function', () => {
+  setupTest({
+    server: true,
+    fixture: 'fixture/with-object-and-header'
+  })
+
+  test('render', async () => {
+    const { body } = await get('/robots.txt')
+    expect(body).toBe('# Comment\nUser-agent: Googlebot\nDisallow: /')
+  })
+})


### PR DESCRIPTION
We are looking to introduce some easter eggs into our site via the robots.txt and for this would like to have the option to introduce comments.

Based on the existing implementation it seems preferable to introduce the idea of a header/footer area that can be configured. This avoids complexity around how to interweave the rules with comments.

Referencing the original `robots.txt` specification:

> Comments are allowed anywhere in the file, and consist of optional
   whitespace, followed by a comment character '#' followed by the
   comment, terminated by the end-of-line.
   https://www.robotstxt.org/norobots-rfc.txt
  
**Proposed behaviour**
  
```
# Cool a customisable header
User-agent: *
Allow: /
# Oh look you can also add a footer if you wish
```
  
Current implementation requires another pass but I wanted to raise early and see if this was something the maintainers would be open to incorporating. 

Here's a compelling round up of some cute things which have been made possible through support for comments:
https://www.onely.com/blog/easter-eggs-robots-txt-files/#Googles_killer-robotstxt