### PR TITLE
fix: config function not passing in req

### DIFF
--- a/src/runtime/server/middleware.ts
+++ b/src/runtime/server/middleware.ts
@@ -42,7 +42,7 @@ async function getRules (options: Rule | Rule[], req = null) {
       const parsedKey = parsed[key]
 
       let values: RuleValue
-      values = typeof parsedKey === 'function' ? await parsedKey.call(req) : parsedKey
+      values = typeof parsedKey === 'function' ? await parsedKey(req) : parsedKey
       values = (Array.isArray(values)) ? values : [values]
 
       for (const value of values) {


### PR DESCRIPTION
While trying to use functions in the config file, the req object was not being passed in. It seems this was being caused by the `.call` usage in the server middleware. I have instead removed it to call the function directly which seemed to have fixed the issue.