### PR TITLE
fix(middleware): call functions directly

### DIFF
--- a/src/runtime/server/middleware.ts
+++ b/src/runtime/server/middleware.ts
@@ -42,7 +42,7 @@ async function getRules (options: Rule | Rule[], req = null) {
       const parsedKey = parsed[key]
 
       let values: RuleValue
-      values = typeof parsedKey === 'function' ? await parsedKey.call(req) : parsedKey
+      values = typeof parsedKey === 'function' ? await parsedKey(req) : parsedKey
       values = (Array.isArray(values)) ? values : [values]
 
       for (const value of values) {


### PR DESCRIPTION
For me, the function given in the README does work without using `call` only. Without this change `req` would currently be `undefined` in the example:
```
Sitemap: (req) => `https://${req.headers.host}/sitemap.xml`
```