### PR TITLE
feat: add blank lines and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,25 @@ export default {
 If you need to use function in any rule, you need to create a config file through the `configPath` option
 
 ```js
-export default {
-  UserAgent: '*',
-  Disallow: '/',
+export default [
+  { UserAgent: '*' },
+  { Disallow: '/' },
+  { BlankLine: true },
+  { Comment: 'Comment here' },
       
   // Be aware that this will NOT work on target: 'static' mode
-  Sitemap: (req) => `https://${req.headers.host}/sitemap.xml`
-}
+  { Sitemap: (req) => `https://${req.headers.host}/sitemap.xml` }
+]
+```
+
+output: 
+
+```txt
+User-agent: *
+Disallow: /
+
+# Comment here
+Sitemap: https://robots.nuxtjs.org/sitemap.xml
 ```
 
 ### The keys and values available:
@@ -92,6 +104,8 @@ export default {
 - Host = `Host`
 - Sitemap = `Sitemap`
 - CleanParam = `Clean-param`
+- Comment = `# Comment`
+- BlankLine = `Add blank line`
 
 **Note:** Don't worry, keys are parsed with case insensitivity and special characters.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,3 @@
-export enum Correspondence {
-  'User-agent',
-  'Crawl-delay',
-  'Disallow',
-  'Allow',
-  'Host',
-  'Sitemap',
-  'Clean-param'
-}
-
-export interface RuleInterface {
-  key: Correspondence
-  value: string
-}
-
 export type RuleValue = string | boolean | Function | (string | boolean | Function)[]
 
 export type Rule = {

--- a/test/config-file.test.ts
+++ b/test/config-file.test.ts
@@ -8,6 +8,6 @@ describe('config file', async () => {
 
   test('render', async () => {
     const body = await $fetch('/robots.txt')
-    expect(body).toBe('User-agent: Googlebot\nUser-agent: Bingbot\nDisallow: /admin')
+    expect(body).toBe('User-agent: Googlebot\nUser-agent: Bingbot\n# Comment here\n\nDisallow: /admin')
   })
 })

--- a/test/fixture/config-file/robots.config.ts
+++ b/test/fixture/config-file/robots.config.ts
@@ -1,4 +1,6 @@
-export default {
-  UserAgent: () => ['Googlebot', () => 'Bingbot'],
-  Disallow: '/admin'
-}
+export default [
+  { UserAgent: () => ['Googlebot', () => 'Bingbot'] },
+  { Comment: 'Comment here' },
+  { BlankLine: true },
+  { Disallow: '/admin' }
+]


### PR DESCRIPTION
Add `BlankLine` and `Comment` keys
Resolve #59

Ex: 
```nuxt.config.ts
export default defineNuxtConfig({
  modules: [
   '@nuxtjs/robots',
  ],
  robots: {
    rules: [
      { UserAgent: '*' },
      { Disallow: '/' },
      { BlankLine: true },
      { Comment: 'Comment here' },
          
      // Be aware that this will NOT work on target: 'static' mode
      { Sitemap: (req) => `https://${req.headers.host}/sitemap.xml` }
    ]
  }
})
```

output:

```txt
User-agent: *
Disallow: /

# Comment here
Sitemap: https://robots.nuxtjs.org/sitemap.xml
```