### PR TITLE
fix: only prerender for static target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 sw.*
 .env
 .output
+*.tgz

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,7 +47,7 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => `export default ${JSON.stringify(options.rules, null, 2)}`
     }).dst || '')
 
-    if (nuxt.options.target === 'static') {
+    if (nuxt.options._generate) {
       nuxt.hook('nitro:build:before', (nitro) => {
         nitro.options.prerender.routes.push(`/${ROBOTS_FILENAME}`)
       })

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,9 +47,11 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => `export default ${JSON.stringify(options.rules, null, 2)}`
     }).dst || '')
 
-    nuxt.hook('nitro:build:before', (nitro) => {
-      nitro.options.prerender.routes.push(`/${ROBOTS_FILENAME}`)
-    })
+    if (nuxt.options.target === 'static') {
+      nuxt.hook('nitro:build:before', (nitro) => {
+        nitro.options.prerender.routes.push(`/${ROBOTS_FILENAME}`)
+      })
+    }
 
     const runtimeDir = resolve('./runtime')
     nuxt.options.build.transpile.push(runtimeDir)

--- a/test/config-file.test.ts
+++ b/test/config-file.test.ts
@@ -8,6 +8,11 @@ describe('config file', async () => {
 
   test('render', async () => {
     const body = await $fetch('/robots.txt')
-    expect(body).toBe('User-agent: Googlebot\nUser-agent: Bingbot\n# Comment here\n\nDisallow: /admin')
+    expect(body).toMatch(/User-agent: Googlebot\nUser-agent: Bingbot\n# Comment here\n\nDisallow: \/admin\nSitemap: https:\/\/127\.0\.0\.1:[0-9]+\/sitemap\.xml/)
+  })
+
+  test('render with different host', async () => {
+    const body = await $fetch('/robots.txt', { headers: { Host: 'robots.test:1234' } })
+    expect(body).toBe('User-agent: Googlebot\nUser-agent: Bingbot\n# Comment here\n\nDisallow: /admin\nSitemap: https://robots.test:1234/sitemap.xml')
   })
 })

--- a/test/fixture/config-file/robots.config.ts
+++ b/test/fixture/config-file/robots.config.ts
@@ -1,9 +1,9 @@
-import { IncomingMessage } from 'node:http'
+import { NodeIncomingMessage } from 'h3'
 
 export default [
   { UserAgent: () => ['Googlebot', () => 'Bingbot'] },
   { Comment: 'Comment here' },
   { BlankLine: true },
   { Disallow: '/admin' },
-  { Sitemap: (req: IncomingMessage) => `https://${req.headers.host}/sitemap.xml` }
+  { Sitemap: (req: NodeIncomingMessage) => `https://${req.headers.host}/sitemap.xml` }
 ]

--- a/test/fixture/config-file/robots.config.ts
+++ b/test/fixture/config-file/robots.config.ts
@@ -1,6 +1,9 @@
+import { IncomingMessage } from 'node:http'
+
 export default [
   { UserAgent: () => ['Googlebot', () => 'Bingbot'] },
   { Comment: 'Comment here' },
   { BlankLine: true },
-  { Disallow: '/admin' }
+  { Disallow: '/admin' },
+  { Sitemap: (req: IncomingMessage) => `https://${req.headers.host}/sitemap.xml` }
 ]

--- a/test/fixture/generate/nuxt.config.js
+++ b/test/fixture/generate/nuxt.config.js
@@ -1,7 +1,6 @@
 import RobotsModule from '../../../src/module'
 
 export default defineNuxtConfig({
-  target: 'static',
   modules: [
     RobotsModule
   ]

--- a/test/fixture/generate/nuxt.config.js
+++ b/test/fixture/generate/nuxt.config.js
@@ -1,6 +1,7 @@
 import RobotsModule from '../../../src/module'
 
 export default defineNuxtConfig({
+  target: 'static',
   modules: [
     RobotsModule
   ]

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -5,7 +5,12 @@ import { setup, useTestContext } from '@nuxt/test-utils'
 
 describe('generate', async () => {
   await setup({
-    fixture: 'fixture/generate'
+    fixture: 'fixture/generate',
+    build: true,
+    server: false,
+    nuxtConfig: {
+      _generate: true
+    }
   })
 
   test('render', () => {


### PR DESCRIPTION
Currently, the `/robots.txt` route is prerendered even for server deployments. A demo for that behavior can be observed in the first commit of this PR which adds a test that currently fails.

Closes #76.